### PR TITLE
Fix for Custom Table Name

### DIFF
--- a/src/managers/DBManager.php
+++ b/src/managers/DBManager.php
@@ -17,7 +17,8 @@ use yii\di\Instance;
  */
 class DBManager extends BaseManager
 {
-    public $tableName = '{{%modelhistory}}';
+    public static $defaultTableName = '{{%modelhistory}}'; // static default for migration
+    public $tableName;
 
     /**
      * @var string
@@ -29,8 +30,10 @@ class DBManager extends BaseManager
      */
     public function saveField($data)
     {
+        $table =  isset($this->tableName) ? $this->tableName : $this::$defaultTableName;
+        
         self::getDB()->createCommand()
-            ->insert($this->tableName, $data)->execute();
+            ->insert($table, $data)->execute();
     }
 
     /**

--- a/src/managers/DBManager.php
+++ b/src/managers/DBManager.php
@@ -17,7 +17,7 @@ use yii\di\Instance;
  */
 class DBManager extends BaseManager
 {
-    public static $tableName = '{{%modelhistory}}';
+    public $tableName = '{{%modelhistory}}';
 
     /**
      * @var string
@@ -29,9 +29,8 @@ class DBManager extends BaseManager
      */
     public function saveField($data)
     {
-        $table =  isset($this->tableName) ? $this->tableName : $this::$tableName;
         self::getDB()->createCommand()
-            ->insert($table, $data)->execute();
+            ->insert($this->tableName, $data)->execute();
     }
 
     /**


### PR DESCRIPTION
Error was:"name":"PHP Strict Warning","message":"Accessing static property nhkey\\arh\\managers\\DBManager::$tableName as non static","code":2048,"type":"yii\\base\\ErrorException","file":"/var/www/public/vendor/nhkey/yii2-activerecord-history/src/managers/BaseManager.php" if customTable was declared at behavior