### PR TITLE
Prevent record for dummy-updated fields

### DIFF
--- a/src/managers/BaseManager.php
+++ b/src/managers/BaseManager.php
@@ -71,8 +71,9 @@ abstract class BaseManager implements ActiveRecordHistoryInterface
                     $data['field_name'] = $updatedFieldKey;
                     $data['old_value'] = $updatedFieldValue;
                     $data['new_value'] = $object->$updatedFieldKey;
-
-                    $this->saveField($data);
+                    if($data['old_value'] != $data['new_value']){
+                        $this->saveField($data);
+                    }
                 }
                 break;
             case self::AR_DELETE:


### PR DESCRIPTION
Perform history record if old_value and new_value are really different as 
$event->changedAttributes may contain unwanted field names (with dummy updated values).