### PR TITLE
Define tableName() in ActiveRecordHistory

### DIFF
--- a/src/ActiveRecordHistory.php
+++ b/src/ActiveRecordHistory.php
@@ -7,6 +7,7 @@
 namespace nhkey\arh;
 
 use nhkey\arh\managers\BaseManager;
+use nhkey\arh\managers\DBManager;
 use Yii;
 
 /**
@@ -27,6 +28,13 @@ class ActiveRecordHistory extends \yii\db\ActiveRecord
      */
     protected $_optionsHistoryManager;
 
+    /**
+     * @inheritdoc
+     */
+    public static function tableName()
+    {
+        return DBManager::$defaultTableName;
+    }
 
     public function afterSave($insert, $changedAttributes)
     {


### PR DESCRIPTION
Define tableName() in ActiveRecordHistory for possibility to use it as relation.