### PR TITLE
Added MongoDB manager

### DIFF
--- a/src/managers/MongoDBManager.php
+++ b/src/managers/MongoDBManager.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace nhkey\arh\managers;
+
+use Yii;
+use yii\mongodb\Connection;
+use yii\di\Instance;
+
+/**
+ * Class MongoDBManager for save history in DB
+ * @package nhkey\arh
+ */
+class MongoDBManager extends DBManager
+{
+    /**
+     * @inheritdoc
+     */
+    public static $defaultTableName = 'modelhistory';
+
+    /**
+     * @inheritdoc
+     */
+    public static $db = 'mongodb';
+
+    /**
+     * @inheritdoc
+     */
+    public function saveField($data)
+    {
+        $table =  isset($this->tableName) ? $this->tableName : $this::$defaultTableName;
+
+        $result = self::getDB()->createCommand()->insert($table, $data);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    private static function getDB()
+    {
+        return Instance::ensure(static::$db, Connection::className());
+    }
+}


### PR DESCRIPTION
Added a manager for MongoDB. Save all history records to MongoDB instead of a relational database.

Relies upon an application component named 'mongodb' being defined in config/web.php.